### PR TITLE
Remove terraform.zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,8 @@ RUN \
   wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
   # Unzip
   unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d "/usr/local/bin" && \
+  # Delete terraform zip
+  rm -rf terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
   # Install docker-compose
   pip install "docker-compose==${DOCKER_COMPOSE_VERSION}"
+  

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# ci
-Trazable's CI
+# Trazable CI Image
+
+Trazable docker image for CI use.
+
+# Composition
+
+Builded on alpine linux
+
+This image contains the next binaries:
+  - Google cloud 271.0.0
+  - Docker 17.12.0-ce
+  - Terraform 0.12.12
+  - Docker-compose 1.24.1


### PR DESCRIPTION
To reduce the image size terraform.zip is removed after its installation.